### PR TITLE
Dave

### DIFF
--- a/static/js/tux.js
+++ b/static/js/tux.js
@@ -81,6 +81,10 @@ class Tux {
             }
             fire = false;
         }
+
+        if (currentAmmo === 0) {
+            fire = false;
+        }
         
         if (!this.sliding) {
             //update hit box area


### PR DESCRIPTION
Fix BUG
> If ammo key pressed when ammo is empty, collection of a snowflake caused first snowball to auto fire.
- add logic to set {fire} back to {false}